### PR TITLE
chore: ignore .DS_Store and remove tracked instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ build/
 .mvn
 
 .angular
+
+### MAC
+.DS_Store
+**/.DS_Store

--- a/back/sonar-project.properties
+++ b/back/sonar-project.properties
@@ -14,3 +14,5 @@ sonar.java.libraries=target/dependency/*.jar
 sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
 sonar.cpd.xml.minimumLines=3
 sonar.cpd.java.minimumLines=3
+
+sonar.exclusions=**/.DS_Store

--- a/front/sonar-project.properties
+++ b/front/sonar-project.properties
@@ -5,3 +5,4 @@ sonar.sources=src
 sonar.tests=src/app
 sonar.test.inclusions=**/*.spec.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.exclusions=**/.DS_Store


### PR DESCRIPTION
fichiers ds_store d'un mac pas corrects pour sonar (binaire) - dans dépôt parent.