### PR TITLE
Workflow test front sonar props

### DIFF
--- a/front/sonar-project.properties
+++ b/front/sonar-project.properties
@@ -8,11 +8,4 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
 
 sonar.exclusions= **/*.spec.ts, **/.DS_Store
-sonar.coverage.exclusions=
-  src/main.ts,
-  src/polyfills.ts,
-  src/environments/**,
-  src/**/*.module.ts,
-  src/**/index.ts,
-  src/test.ts,
-  **/.DS_Store
+sonar.coverage.exclusions=src/main.ts,src/polyfills.ts,src/environments/**,src/**/*.module.ts,src/**/index.ts,src/test.ts,**/.DS_Store

--- a/front/sonar-project.properties
+++ b/front/sonar-project.properties
@@ -2,7 +2,17 @@ sonar.projectKey=cpierres_P10cicd-frontend
 sonar.projectName=P10cicd-frontend
 
 sonar.sources=src
-sonar.tests=src/app
+sonar.tests=src
 sonar.test.inclusions=**/*.spec.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.exclusions=**/.DS_Store
+sonar.typescript.lcov.reportPaths=coverage/lcov.info
+
+sonar.exclusions= **/*.spec.ts, **/.DS_Store
+sonar.coverage.exclusions=
+  src/main.ts,
+  src/polyfills.ts,
+  src/environments/**,
+  src/**/*.module.ts,
+  src/**/index.ts,
+  src/test.ts,
+  **/.DS_Store


### PR DESCRIPTION
github workflow front : du fait d'un taux de coverage différent entre lcov et sonar (ce dernier moins favorable), cette nouvelle configuraton pour sonar permet de rapprocher les résultats